### PR TITLE
Use task level attributes for workfile settings

### DIFF
--- a/client/ayon_fusion/api/lib.py
+++ b/client/ayon_fusion/api/lib.py
@@ -8,7 +8,7 @@ from ayon_core.style import load_stylesheet
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.create import CreateContext
 from ayon_core.pipeline.context_tools import (
-    get_current_folder_entity,
+    get_current_folder_path,
     get_current_task_entity
 )
 
@@ -128,8 +128,8 @@ def validate_comp_prefs(comp=None, force_repair=False):
         "attrib.pixelAspect",
     }
     task_entity = get_current_task_entity(fields=fields)
-    folder_entity = get_current_folder_entity(fields={"path"})
-    context_path = "{} > {}".format(folder_entity["path"], task_entity["name"])
+    folder_path = get_current_folder_path()
+    context_path = "{} > {}".format(folder_path, task_entity["name"])
 
     task_attributes = task_entity["attrib"]
 

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -20,7 +20,7 @@ class CreateSaver(GenericCreateSaver):
     product_type = "render"
     description = "Fusion Saver to generate image sequence"
 
-    default_frame_range_option = "current_folder"
+    default_frame_range_option = "current_task"
 
     def get_detail_description(self):
         return """Fusion Saver to generate image sequence.
@@ -56,8 +56,7 @@ class CreateSaver(GenericCreateSaver):
 
     def _get_frame_range_enum(self):
         frame_range_options = {
-            # The `current_folder` value is kept for backwards compatibility
-            "current_folder": "Current task context",
+            "current_task": "Current task context",
             "render_range": "From render in/out",
             "comp_range": "From composition timeline",
             "custom_range": "Custom frame range",

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -56,7 +56,8 @@ class CreateSaver(GenericCreateSaver):
 
     def _get_frame_range_enum(self):
         frame_range_options = {
-            "current_folder": "Current Folder context",
+            # The `current_folder` value is kept for backwards compatibility
+            "current_folder": "Current task context",
             "render_range": "From render in/out",
             "comp_range": "From composition timeline",
             "custom_range": "Custom frame range",

--- a/client/ayon_fusion/plugins/publish/collect_instances.py
+++ b/client/ayon_fusion/plugins/publish/collect_instances.py
@@ -26,7 +26,7 @@ class CollectInstanceData(pyblish.api.InstancePlugin):
         instance.data["frame_range_source"] = frame_range_source
 
         # get folder frame ranges to all instances
-        # render product type instances `current_folder` render target
+        # render product type instances `current_task` render target
         start = context.data["frameStart"]
         end = context.data["frameEnd"]
         handle_start = context.data["handleStart"]

--- a/client/ayon_fusion/plugins/publish/validate_saver_resolution.py
+++ b/client/ayon_fusion/plugins/publish/validate_saver_resolution.py
@@ -55,7 +55,15 @@ class ValidateSaverResolution(
 
     @classmethod
     def get_expected_resolution(cls, instance):
-        attributes = instance.data["folderEntity"]["attrib"]
+
+        entity = instance.data.get("taskEntity")
+        if not entity:
+            cls.log.debug(
+                "Using folder entity resolution for validation because "
+                f"task entity not found for instance: {instance}")
+            entity = instance.data["folderEntity"]
+
+        attributes = entity["attrib"]
         return attributes["resolutionWidth"], attributes["resolutionHeight"]
 
     @classmethod

--- a/server/settings.py
+++ b/server/settings.py
@@ -37,9 +37,10 @@ def _image_format_enum():
 
 def _frame_range_options_enum():
     return [
-        {"value": "asset_db", "label": "Current asset context"},
+        {"value": "current_task", "label": "Current task context"},
         {"value": "render_range", "label": "From render in/out"},
         {"value": "comp_range", "label": "From composition timeline"},
+        {"value": "custom_range", "label": "Custom frame range"},
     ]
 
 
@@ -85,7 +86,7 @@ class HooksModel(BaseSettingsModel):
 
 class CreateSaverModel(CreateSaverPluginModel):
     default_frame_range_option: str = SettingsField(
-        default="asset_db",
+        default="current_task",
         enum_resolver=_frame_range_options_enum,
         title="Default frame range source"
     )
@@ -162,7 +163,7 @@ DEFAULT_VALUES = {
                 "farm_rendering"
             ],
             "image_format": "exr",
-            "default_frame_range_option": "asset_db"
+            "default_frame_range_option": "current_task"
         },
         "CreateImageSaver": {
             "temp_rendering_path_template": "{workdir}/renders/fusion/{product[name]}/{product[name]}.{ext}",


### PR DESCRIPTION
## Changelog Description

Use task level attributes for setting comp workfile settings and validations on workfile save.

## Additional info

FPS and comp resolution should be set on new comp and validated on save to match the task entity instead of folder entity.

## Testing notes:

1. Workfile new, workfile save and publish should adhere to the task entity attributes instead of folder entity.