### PR TITLE
Trigger prelaunch hooks on farm that define the profile to run (AY-6902)

### DIFF
--- a/client/ayon_fusion/hooks/pre_fusion_profile_hook.py
+++ b/client/ayon_fusion/hooks/pre_fusion_profile_hook.py
@@ -27,7 +27,11 @@ class FusionCopyPrefsPrelaunch(PreLaunchHook):
 
     app_groups = {"fusion"}
     order = 2
-    launch_types = {LaunchTypes.local}
+    launch_types = {LaunchTypes.local,
+                    LaunchTypes.farm_render,
+                    # This seems to be incorrectly configured for
+                    # ayon_applications addon, see `ayon_applications/#2`
+                    LaunchTypes.farm_publish}
 
     def get_fusion_profile_name(self, profile_version) -> str:
         # Returns 'Default', unless FUSION16_PROFILE is set

--- a/client/ayon_fusion/hooks/pre_fusion_setup.py
+++ b/client/ayon_fusion/hooks/pre_fusion_setup.py
@@ -23,7 +23,11 @@ class FusionPrelaunch(PreLaunchHook):
 
     app_groups = {"fusion"}
     order = 1
-    launch_types = {LaunchTypes.local}
+    launch_types = {LaunchTypes.local,
+                    LaunchTypes.farm_render,
+                    # This seems to be incorrectly configured for
+                    # ayon_applications addon, see `ayon_applications/#2`
+                    LaunchTypes.farm_publish}
 
     def execute(self):
         # making sure python 3 is installed at provided path


### PR DESCRIPTION
## Changelog Description

Trigger prelaunch hooks on farm that define the profile to run. This also ensures all relevant tools/plugins configured for Fusion are also available on the farm renders in e.g. Deadline

## Additional info

...

## Testing notes:

1. The Fusion profiles and master preferences should also apply on farm jobs.

AY-6902
