### PR TITLE
Set loader name on "Load sequence"

### DIFF
--- a/client/ayon_fusion/plugins/load/load_sequence.py
+++ b/client/ayon_fusion/plugins/load/load_sequence.py
@@ -161,6 +161,7 @@ class FusionLoadSequence(load.LoaderPlugin):
             args = (-32768, -32768)
             tool = comp.AddTool("Loader", *args)
             tool["Clip"] = comp.ReverseMapPath(path)
+            tool.SetAttrs({"TOOLB_NameSet": True, "TOOLS_Name": name})
 
             # Set global in point to start frame (if in version.data)
             start = self._get_start(context["version"], tool)


### PR DESCRIPTION
## Changelog Description
Simple change to use the existing `name` argument to set the loaders name attribute.

## Additional info
Before: 
![image](https://github.com/user-attachments/assets/7555b9f2-abd3-431d-bdef-e041562c2440) 
![image](https://github.com/user-attachments/assets/8d349301-588c-4fe5-bf59-c0054fefd6bc)

After: 
![image](https://github.com/user-attachments/assets/c85884e5-2ee7-4173-917d-b2675c449141)
![image](https://github.com/user-attachments/assets/a8e02805-52dc-451e-a776-02bac751d211)

## Testing notes:
1. load sequence from AYON Loader
2. check the new created node name reflects the selected sequence from AYON Loader
