### PR TITLE
Creators improve descriptions

### DIFF
--- a/client/ayon_fusion/plugins/create/create_image_saver.py
+++ b/client/ayon_fusion/plugins/create/create_image_saver.py
@@ -17,12 +17,12 @@ class CreateImageSaver(GenericCreateSaver):
     label = "Image (saver)"
     name = "image"
     product_type = "image"
-    description = "Fusion Saver to generate image"
+    description = "Fusion Saver to generate a single image file"
 
     default_frame = 0
 
     def get_detail_description(self):
-        return """Fusion Saver to generate single image.
+        return """Fusion Saver to generate a single image file.
 
         This creator is expected for publishing of single frame `image` product
         type.

--- a/client/ayon_fusion/plugins/create/create_image_saver.py
+++ b/client/ayon_fusion/plugins/create/create_image_saver.py
@@ -1,3 +1,5 @@
+import inspect
+
 from ayon_core.lib import NumberDef
 
 from ayon_fusion.api.plugin import GenericCreateSaver
@@ -22,26 +24,29 @@ class CreateImageSaver(GenericCreateSaver):
     default_frame = 0
 
     def get_detail_description(self):
-        return """Fusion Saver to generate a single image file.
+        return inspect.cleandoc(
+            """Fusion Saver to generate a single image file.
 
-        This creator is expected for publishing of single frame `image` product
-        type.
-
-        Artist should provide frame number (integer) to specify which frame
-        should be published. It must be inside of global timeline frame range.
-
-        Supports local and deadline rendering.
-
-        Supports selection from predefined set of output file extensions:
-        - exr
-        - tga
-        - png
-        - tif
-        - jpg
-
-        Created to explicitly separate single frame ('image') or
-        multi frame ('render') outputs.
-        """
+            This creator is expected for publishing of single frame `image` 
+            product type.
+    
+            Artist should provide frame number (integer) to specify which frame
+            should be published. It must be inside of global timeline frame 
+            range.
+    
+            Supports local and deadline rendering.
+    
+            Supports selection from predefined set of output file extensions:
+            - exr
+            - tga
+            - png
+            - tif
+            - jpg
+    
+            Created to explicitly separate single frame ('image') or
+            multi frame ('render') outputs.
+            """
+        )
 
     def get_pre_create_attr_defs(self):
         """Settings for create page"""

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -1,3 +1,5 @@
+import inspect
+
 from ayon_core.lib import (
     UILabelDef,
     NumberDef,
@@ -23,25 +25,28 @@ class CreateSaver(GenericCreateSaver):
     default_frame_range_option = "current_folder"
 
     def get_detail_description(self):
-        return """Fusion Saver to generate image sequence.
+        return inspect.cleandoc(
+            """Fusion Saver to generate image sequence.
 
-        This creator is expected for publishing of image sequences for 'render'
-        product type. (But can publish even single frame 'render'.)
-
-        Select what should be source of render range:
-        - "Current Folder context" - values set on folder on AYON server
-        - "From render in/out" - from node itself
-        - "From composition timeline" - from timeline
-
-        Supports local and farm rendering.
-
-        Supports selection from predefined set of output file extensions:
-        - exr
-        - tga
-        - png
-        - tif
-        - jpg
-        """
+            This creator is expected for publishing of image sequences for 
+            'render' product type. (But can publish even single frame 
+            'render'.)
+    
+            Select what should be source of render range:
+            - "Current Folder context" - values set on folder on AYON server
+            - "From render in/out" - from node itself
+            - "From composition timeline" - from timeline
+    
+            Supports local and farm rendering.
+    
+            Supports selection from predefined set of output file extensions:
+            - exr
+            - tga
+            - png
+            - tif
+            - jpg
+            """
+        )
 
     def get_pre_create_attr_defs(self):
         """Settings for create page"""

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -18,12 +18,12 @@ class CreateSaver(GenericCreateSaver):
     label = "Render (saver)"
     name = "render"
     product_type = "render"
-    description = "Fusion Saver to generate image sequence"
+    description = "Fusion Saver to generate a multi-file image sequence"
 
     default_frame_range_option = "current_folder"
 
     def get_detail_description(self):
-        return """Fusion Saver to generate image sequence.
+        return """Fusion Saver to generate a multi-file image sequence.
 
         This creator is expected for publishing of image sequences for 'render'
         product type. (But can publish even single frame 'render'.)

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -18,12 +18,12 @@ class CreateSaver(GenericCreateSaver):
     label = "Render (saver)"
     name = "render"
     product_type = "render"
-    description = "Fusion Saver to generate a multi-file image sequence"
+    description = "Fusion Saver to generate image sequence"
 
     default_frame_range_option = "current_folder"
 
     def get_detail_description(self):
-        return """Fusion Saver to generate a multi-file image sequence.
+        return """Fusion Saver to generate image sequence.
 
         This creator is expected for publishing of image sequences for 'render'
         product type. (But can publish even single frame 'render'.)


### PR DESCRIPTION
## Changelog Description
Slight tweaks to create saver descriptions.

## Additional info
We had some user confusion between image and render creators so hope to address that by improving the descriptions slightly.

## Testing notes:
1. open AYON Publisher Create tab
2. select Image (saver) and view the new description
3. select Render (saver) and view the new description
