### PR TITLE
Show/hide custom frame range attributes based on Frame Range source value

### DIFF
--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -111,10 +111,11 @@ class CreateSaver(GenericCreateSaver):
 
         # If an instance is provided and 'custom_range' is not the frame
         # range source, then we will disable the custom frame range attributes
-        custom_disabled = False
+        custom_enabled = True
         if instance is not None:
-            frame_range_source = instance.get("creator_attributes", {}).get("frame_range_source")
-            custom_disabled = frame_range_source != "custom_range"
+            frame_range_source = instance.get(
+                "creator_attributes", {}).get("frame_range_source")
+            custom_enabled = frame_range_source == "custom_range"
 
         # Define custom frame range defaults based on current comp
         # timeline settings (if a comp is currently open)
@@ -140,7 +141,7 @@ class CreateSaver(GenericCreateSaver):
             }
 
         attr_defs = []
-        if not custom_disabled:
+        if not custom_enabled:
             # UILabelDef does not support `hidden` argument so we exclude it
             # manually
             attr_defs.append(
@@ -160,7 +161,7 @@ class CreateSaver(GenericCreateSaver):
                     "Set the start frame for the export.\n"
                     "Only used if frame range source is 'Custom frame range'."
                 ),
-                hidden=custom_disabled
+                visible=custom_enabled
             ),
             NumberDef(
                 "custom_frameEnd",
@@ -172,7 +173,7 @@ class CreateSaver(GenericCreateSaver):
                     "Set the end frame for the export.\n"
                     "Only used if frame range source is 'Custom frame range'."
                 ),
-                hidden=custom_disabled
+                visible=custom_enabled
             ),
             NumberDef(
                 "custom_handleStart",
@@ -185,7 +186,7 @@ class CreateSaver(GenericCreateSaver):
                     "added before the start frame.\n"
                     "Only used if frame range source is 'Custom frame range'."
                 ),
-                hidden=custom_disabled
+                visible=custom_enabled
             ),
             NumberDef(
                 "custom_handleEnd",
@@ -198,7 +199,7 @@ class CreateSaver(GenericCreateSaver):
                     "after the end frame.\n"
                     "Only used if frame range source is 'Custom frame range'."
                 ),
-                hidden=custom_disabled
+                visible=custom_enabled
             )
         ])
         return attr_defs

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -141,7 +141,7 @@ class CreateSaver(GenericCreateSaver):
             }
 
         attr_defs = []
-        if not custom_enabled:
+        if custom_enabled:
             # UILabelDef does not support `hidden` argument so we exclude it
             # manually
             attr_defs.append(

--- a/package.py
+++ b/package.py
@@ -6,6 +6,6 @@ client_dir = "ayon_fusion"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">0.3.2",
+    "core": ">1.0.3",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description

Show/hide custom frame range attributes based on Frame Range source value

## Additional info

Requires PR https://github.com/ynput/ayon-core/pull/935

## Testing notes:

1. Publisher UI instance attributes should toggle "custom frame range" attributes based on the Frame Range source set on the instance.

![image](https://github.com/user-attachments/assets/53c8d92d-d44e-40d7-97c9-5b0cb0624efc)

![image](https://github.com/user-attachments/assets/11c405e9-c306-4ba0-8a03-92d877a94eb9)

