### PR TITLE
Create Saver: Do not error on context attribute value change

### DIFF
--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -57,6 +57,10 @@ class CreateSaver(GenericCreateSaver):
         for instance_change in event["changes"]:
             # First check if there's a change we want to respond to
             instance = instance_change["instance"]
+            if instance is None:
+                # Change is on context
+                continue
+
             if instance["creator_identifier"] != self.identifier:
                 continue
 


### PR DESCRIPTION
## Changelog Description

Create Saver: Do not error on context attribute value change

## Additional review information

Similar fix as https://github.com/ynput/ayon-maya/pull/171 based on error [reported here](https://github.com/ynput/ayon-core/pull/982#pullrequestreview-2414976747) but then for Create Saver in Fusion.

## Testing notes:

1. Create saver instance
2. Trigger context attribute change
3. No error should occur
