### PR TITLE
Suppress Render Completed dialog on local render

### DIFF
--- a/client/ayon_fusion/plugins/publish/extract_render_local.py
+++ b/client/ayon_fusion/plugins/publish/extract_render_local.py
@@ -10,6 +10,10 @@ from ayon_fusion.api.lib import get_frame_path, maintained_comp_range
 
 log = logging.getLogger(__name__)
 
+# Fusion render flag to avoid Render Completed dialog to pop up after render
+# See: https://www.steakunderwater.com/wesuckless/viewtopic.php?p=53312
+REQF_Quiet = 524288
+
 
 @contextlib.contextmanager
 def enabled_savers(comp, savers):
@@ -125,6 +129,7 @@ class FusionRenderLocal(
                             "Start": frame_start,
                             "End": frame_end,
                             "Wait": True,
+                            "RenderFlags": REQF_Quiet
                         }
                     )
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -112,6 +112,24 @@ class CreatPluginsModel(BaseSettingsModel):
     )
 
 
+class FusionRenderLocalModel(BaseSettingsModel):
+    suppress_dialogs: bool = SettingsField(
+        True,
+        title="Suppress Fusion dialogs",
+        description=(
+            "Suppress the Fusion 'Render Completed' and 'Render Failed'"
+            " dialogs.")
+    )
+
+
+class PublishPluginsModel(BaseSettingsModel):
+    FusionRenderLocal: FusionRenderLocalModel = SettingsField(
+        default_factory=FusionRenderLocalModel,
+        title="Render Local",
+        description="Plug-in to render in current Fusion session."
+    )
+
+
 class FusionSettings(BaseSettingsModel):
     imageio: FusionImageIOModel = SettingsField(
         default_factory=FusionImageIOModel,
@@ -128,6 +146,10 @@ class FusionSettings(BaseSettingsModel):
     create: CreatPluginsModel = SettingsField(
         default_factory=CreatPluginsModel,
         title="Creator plugins"
+    )
+    publish: PublishPluginsModel = SettingsField(
+        default_factory=PublishPluginsModel,
+        title="Publish plugins"
     )
 
 
@@ -177,6 +199,11 @@ DEFAULT_VALUES = {
             ],
             "image_format": "exr",
             "default_frame": 0
+        }
+    },
+    "publish": {
+        "FusionRenderLocal": {
+            "suppress_dialogs": True
         }
     }
 }


### PR DESCRIPTION
## Changelog Description

Suppress the Render Completed dialog on a local Fusion render.

## Additional review information

Avoids this dialog:
![image](https://github.com/user-attachments/assets/4708ef48-d62e-4a16-82d4-df791128e9a8)

Also see: https://www.steakunderwater.com/wesuckless/viewtopic.php?p=53315
Or on Fusion discord: https://discord.com/channels/793508729785155594/793510371323019314/1303956948567461890

## Testing notes:

1. Publish a render set to render locally
