### PR TITLE
Imprint and parse project name for loaded containers

### DIFF
--- a/.github/workflows/validate_pr_labels.yml
+++ b/.github/workflows/validate_pr_labels.yml
@@ -1,0 +1,18 @@
+name: 🔎 Validate PR Labels
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  validate-type-label:
+    uses: ynput/ops-repo-automation/.github/workflows/validate_pr_labels.yml@develop
+    with:
+      repo: "${{ github.repository }}"
+      pull_request_number: ${{ github.event.pull_request.number }}
+      query_prefix: "type: "
+    secrets:
+      token: ${{ secrets.YNPUT_BOT_TOKEN }}

--- a/client/ayon_fusion/api/pipeline.py
+++ b/client/ayon_fusion/api/pipeline.py
@@ -324,7 +324,7 @@ def parse_container(tool):
     optional = ["project_name"]
     for key in optional:
         if key in data:
-            container[key] = data
+            container[key] = data[key]
 
     # Store the tool's name
     container["objectName"] = tool.Name

--- a/client/ayon_fusion/api/pipeline.py
+++ b/client/ayon_fusion/api/pipeline.py
@@ -294,6 +294,7 @@ def imprint_container(tool,
         ("namespace", str(namespace)),
         ("loader", str(loader)),
         ("representation", context["representation"]["id"]),
+        ("project_name", context["project"]["name"]),
     ]
 
     for key, value in data:
@@ -318,6 +319,12 @@ def parse_container(tool):
         return
 
     container = {key: data[key] for key in required}
+
+    # Add optional keys, like `project_name`
+    optional = ["project_name"]
+    for key in optional:
+        if key in data:
+            container[key] = data
 
     # Store the tool's name
     container["objectName"] = tool.Name


### PR DESCRIPTION
## Changelog Description

Support loading containers with project name from another project - to allow managing loaded products from e.g. library project

## Additional review information

Requires https://github.com/ynput/ayon-core/pull/1005

## Testing notes:

1. Load products from Library Project
2. They should appear fine in scene inventory and should be update-able.
3. Regular (old) local project containers should also still continue to work.
