### PR TITLE
Collect render instance resolution from the tool in comp instead of from comp frame format prefs

### DIFF
--- a/client/ayon_fusion/plugins/publish/validate_saver_resolution.py
+++ b/client/ayon_fusion/plugins/publish/validate_saver_resolution.py
@@ -54,7 +54,7 @@ class ValidateSaverResolution(
 
         try:
             return get_tool_resolution(saver, frame=first_frame)
-        except ValueError as exc:
+        except ValueError:
             raise PublishValidationError(
                 "Cannot get resolution info for frame '{}'.\n\n "
                 "Please check that saver has connected input.".format(


### PR DESCRIPTION
## Changelog Description

Collect render resolution from the actual tool in comp instead of from comp frame format prefs

## Additional review information

This fixes the behavior that setting Extract Review resolution to 0x0 in settings that the resolution would be forced to the Frame Format Prefs (instead of the resolution from the rendered media)

## Testing notes:

1. Set Extract Review settings in core to use output resolution 0x0
2. Set current context to use e.g. resolution 1000x1000
3. Create a render graph that actually renders e.g. 300x200
4. Publish it (disable resolution validator of course)
5. The generated review should be 300x200.
