### PR TITLE
Pre-launch hooks: Use addon name instead of host name as settings key

### DIFF
--- a/client/ayon_fusion/hooks/pre_fusion_launch_menu_hook.py
+++ b/client/ayon_fusion/hooks/pre_fusion_launch_menu_hook.py
@@ -10,7 +10,7 @@ class FusionLaunchMenuHook(PreLaunchHook):
 
     def execute(self):
         # Prelaunch hook is optional
-        settings = self.data["project_settings"][self.host_name]
+        settings = self.data["project_settings"]["fusion"]
         if not settings["hooks"]["FusionLaunchMenuHook"]["enabled"]:
             return
 

--- a/client/ayon_fusion/hooks/pre_pyside_install.py
+++ b/client/ayon_fusion/hooks/pre_pyside_install.py
@@ -22,7 +22,7 @@ class InstallPySideToFusion(PreLaunchHook):
     def execute(self):
         # Prelaunch hook is not crucial
         try:
-            settings = self.data["project_settings"][self.host_name]
+            settings = self.data["project_settings"]["fusion"]
             if not settings["hooks"]["InstallPySideToFusion"]["enabled"]:
                 return
             self.inner_execute()


### PR DESCRIPTION
## Changelog Description
Use explicit addon name instead of host name to get addon settings.

## Additional review information
Because addon name and host name are same it did work, but code-wise is confusing. It should look explicitly for addon name, not host name (confusing those who use other addons as example).

## Testing notes:
1. Validate the reasoning of the change.
2. Nothing really changed technically.
