### PR TITLE
Add extra anatomy data to formatting data

### DIFF
--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -15,8 +15,12 @@ from ayon_core.pipeline import (
     CreatedInstance,
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
+    template_data
 )
 from ayon_core.pipeline.workfile import get_workdir
+from ayon_core.pipeline.anatomy.anatomy import Anatomy
+from ayon_core.pipeline.context_tools import get_current_host_name
+
 from ayon_api import (
     get_project,
     get_folder_by_path,
@@ -204,6 +208,18 @@ class GenericCreateSaver(Creator):
             self.temp_rendering_path_template
             .replace("{task}", "{task[name]}")
         )
+
+        host_name = get_current_host_name()
+        project_name = self.create_context.get_current_project_name()
+        extra_data = template_data.get_template_data_with_names(
+            project_name,
+            data["folderPath"],
+            data["task"],
+            host_name
+        )
+        anatomy = Anatomy(project_name)
+        extra_data["root"] = anatomy.roots
+        formatting_data.update(extra_data)
 
         filepath = temp_rendering_path_template.format(**formatting_data)
 

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -19,13 +19,6 @@ from ayon_core.pipeline import (
 )
 from ayon_core.pipeline.workfile import get_workdir
 from ayon_core.pipeline.anatomy.anatomy import Anatomy
-from ayon_core.pipeline.context_tools import get_current_host_name
-
-from ayon_api import (
-    get_project,
-    get_folder_by_path,
-    get_task_by_name
-)
 
 
 class GenericCreateSaver(Creator):

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -150,7 +150,7 @@ class GenericCreateSaver(Creator):
         # get output format
         ext = data["creator_attributes"]["image_format"]
 
-        # Product change detected
+        # Product name and type
         product_type = formatting_data["productType"]
         f_product_name = formatting_data["productName"]
 

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -195,8 +195,7 @@ class GenericCreateSaver(Creator):
             host_name=self.create_context.host_name,
             settings=self.create_context.get_current_project_settings(),
         )
-        anatomy = Anatomy(project_entity["name"],
-                          project_entity=project_entity)
+        anatomy = self.create_context.project_anatomy
         extra_data["root"] = anatomy.roots
         formatting_data.update(extra_data)
 

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -15,8 +15,8 @@ from ayon_core.pipeline import (
     CreatedInstance,
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
-    template_data
 )
+from ayon_core.pipeline.template_data import get_template_data
 from ayon_core.pipeline.workfile import get_workdir
 from ayon_core.pipeline.anatomy.anatomy import Anatomy
 
@@ -188,7 +188,7 @@ class GenericCreateSaver(Creator):
             .replace("{task}", "{task[name]}")
         )
 
-        extra_data = template_data.get_template_data(
+        extra_data = get_template_data(
             project_entity,
             folder_entity,
             task_entity,

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -189,7 +189,6 @@ class GenericCreateSaver(Creator):
         })
 
         # build file path to render
-        # TODO make sure the keys are available in 'formatting_data'
         temp_rendering_path_template = (
             self.temp_rendering_path_template
             .replace("{task}", "{task[name]}")

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -183,15 +183,7 @@ class GenericCreateSaver(Creator):
                 "name": f_product_name,
                 "type": product_type,
             },
-            # TODO add more variants for 'folder' and 'task'
-            "folder": {
-                "name": folder_name,
-            },
-            "task": {
-                "name": data["task"],
-            },
             # Backwards compatibility
-            "asset": folder_name,
             "subset": f_product_name,
             "family": product_type,
         })

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -167,7 +167,10 @@ class GenericCreateSaver(Creator):
         ):
             workdir = os.path.normpath(os.getenv("AYON_WORKDIR"))
         else:
-            # TODO: This may error when no task is set for the instance
+            # Note: This may error when no task is set for the instance
+            #  however default render template would include task name anyway
+            #  disallowing the instance to have no task set at an earlier stage
+            #  already.
             workdir = get_workdir(
                 project_entity=project_entity,
                 folder_entity=folder_entity,


### PR DESCRIPTION
In fusion -> Creator plugins -> Create Saver
For the Temporary rendering path template, we cannot use the same syntax as the ones we use in anatomy.
I have updated the formatting data to include those data so we can do so.

![image](https://github.com/user-attachments/assets/b03c46b3-1c71-4f90-a44b-05eb65e733a4)
