### PR TITLE
Rename loader on "update"

### DIFF
--- a/client/ayon_fusion/plugins/load/load_sequence.py
+++ b/client/ayon_fusion/plugins/load/load_sequence.py
@@ -244,9 +244,15 @@ class FusionLoadSequence(load.LoaderPlugin):
                         "TimeCodeOffset",
                     ),
                 ):
-                    self.logging.info(context)
-                    self.logging.info(repre_entity)
                     tool["Clip"] = comp.ReverseMapPath(path)
+                    tool.SetAttrs(
+                        {
+                            "TOOLB_NameSet": True,
+                            "TOOLS_Name": repre_entity["context"]["product"][
+                                "name"
+                            ],
+                        }
+                    )
 
             # Set the global in to the start frame of the sequence
             global_in_changed = loader_shift(tool, start, relative=False)

--- a/client/ayon_fusion/plugins/load/load_sequence.py
+++ b/client/ayon_fusion/plugins/load/load_sequence.py
@@ -244,6 +244,8 @@ class FusionLoadSequence(load.LoaderPlugin):
                         "TimeCodeOffset",
                     ),
                 ):
+                    self.logging.info(context)
+                    self.logging.info(repre_entity)
                     tool["Clip"] = comp.ReverseMapPath(path)
 
             # Set the global in to the start frame of the sequence


### PR DESCRIPTION
## Changelog Description
Related to #18, we made it so the loader name was set on initial load but we did not include the same behavior to the `update` function this PR sets out to remedy that oversight. 

## Additional review information
Very simple PR, just using the same method in #18 but in the update function.

## Testing notes:
1. load sequence from AYON loader
2. open AYON manager
3. switch folder context to trigger `update` function
4. validate that loader name has updated to new product name
