### PR TITLE
Remove `Scripts:` entry from AYON Fusion MasterPrefs path mapping

### DIFF
--- a/client/ayon_fusion/deploy/ayon/fusion_shared.prefs
+++ b/client/ayon_fusion/deploy/ayon/fusion_shared.prefs
@@ -5,7 +5,6 @@ Global = {
     Map = {
       ["AYON:"] = "$(AYON_FUSION_ROOT)/deploy/ayon",
       ["Config:"] = "UserPaths:Config;AYON:Config",
-      ["Scripts:"] = "UserPaths:Scripts;Reactor:System/Scripts",
     },
   },
   Script = {


### PR DESCRIPTION
## Changelog Description

Remove `Scripts:` entry from AYON Fusion MasterPrefs path mapping

## Additional review information

It should not be needed and can be customized if anyone needs in a different manner, e.g. by stacking master prefs - using #44.

## Testing notes:

1. Fusion integration, tools and AYON menu should still work as usual.