### PR TITLE
Add `dpx` image format to settings and enum

### DIFF
--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -272,7 +272,7 @@ class GenericCreateSaver(Creator):
         )
 
     def _get_image_format_enum(self):
-        image_format_options = ["exr", "tga", "tif", "png", "jpg"]
+        image_format_options = ["exr", "tga", "tif", "png", "jpg", "dpx"]
         return EnumDef(
             "image_format",
             items=image_format_options,

--- a/server/settings.py
+++ b/server/settings.py
@@ -32,6 +32,7 @@ def _image_format_enum():
         {"value": "png", "label": "png"},
         {"value": "tif", "label": "tif"},
         {"value": "jpg", "label": "jpg"},
+        {"value": "dpx", "label": "dpx"},
     ]
 
 


### PR DESCRIPTION
## Changelog Description

Add `dpx` image format to settings and enum

## Additional review information

Came up here: https://community.ynput.io/t/creator-plugins-output-image-format/2611?u=bigroy

## Testing notes:
1. `dpx` image format should be available
2. creation and publishing should work
