### PR TITLE
Publish: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_fusion/plugins/publish/increment_current_file.py
+++ b/client/ayon_fusion/plugins/publish/increment_current_file.py
@@ -1,9 +1,11 @@
+import os
+
 import pyblish.api
 
-from ayon_core.pipeline import OptionalPyblishPluginMixin
+from ayon_core.pipeline import OptionalPyblishPluginMixin, registered_host
 from ayon_core.lib import version_up
+from ayon_core.host import IWorkfileHost
 from ayon_fusion.api import FusionHost
-from ayon_core.pipeline import registered_host
 
 
 class FusionIncrementCurrentFile(
@@ -25,30 +27,39 @@ class FusionIncrementCurrentFile(
         comp = context.data.get("currentComp")
         assert comp, "Must have comp"
 
-        current_filepath = context.data["currentFile"]
-        new_filepath = version_up(current_filepath)
-
+        # Fusion can have multiple compositions open at the same time, and
+        # as a publish is running the user may switch to another comp
+        # simultaneously. Hence, we need to ensure the active comp is the
+        # one current publish session is for in the registered host.
         host: FusionHost = registered_host()
         with host.current_comp(comp):
-            # Fusion can have multiple compositions open at the same time, and
-            # as a publish is running the user may switch to another comp
-            # simultaneously. Hence, we need to ensure the active comp is the
-            # one current publish session is for.
-            if hasattr(host, "save_workfile_with_context"):
-                from ayon_core.host.interfaces import SaveWorkfileOptionalData
-                host.save_workfile_with_context(
-                    filepath=new_filepath,
-                    folder_entity=context.data["folderEntity"],
-                    task_entity=context.data["taskEntity"],
-                    description="Incremented by publishing.",
-                    # Optimize the save by reducing needed queries for context
-                    prepared_data=SaveWorkfileOptionalData(
-                        project_entity=context.data["projectEntity"],
-                        project_settings=context.data["project_settings"],
-                        anatomy=context.data["anatomy"],
-                    )
+            self.increment_workfile(context)
+
+    def increment_workfile(self, context: pyblish.api.Context):
+        """Increment the current workfile version using registered host."""
+        current_filepath: str = context.data["currentFile"]
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
+
+            current_filename = os.path.basename(current_filepath)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
                 )
-            else:
-                # Backwards compatibility before:
-                # https://github.com/ynput/ayon-core/pull/1275
-                host.save_workfile(new_filepath)
+            )
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_filepath = version_up(current_filepath)
+            host: IWorkfileHost = registered_host()
+            host.save_workfile(new_filepath)

--- a/client/ayon_fusion/plugins/publish/increment_current_file.py
+++ b/client/ayon_fusion/plugins/publish/increment_current_file.py
@@ -1,7 +1,9 @@
 import pyblish.api
 
 from ayon_core.pipeline import OptionalPyblishPluginMixin
-from ayon_core.pipeline import KnownPublishError
+from ayon_core.lib import version_up
+from ayon_fusion.api import FusionHost
+from ayon_core.pipeline import registered_host
 
 
 class FusionIncrementCurrentFile(
@@ -9,9 +11,7 @@ class FusionIncrementCurrentFile(
 ):
     """Increment the current file.
 
-    Saves the current file with an increased version number.
-
-    """
+    Saves the current file with an increased version number."""
 
     label = "Increment workfile version"
     order = pyblish.api.IntegratorOrder + 9.0
@@ -22,23 +22,33 @@ class FusionIncrementCurrentFile(
         if not self.is_active(context.data):
             return
 
-        from ayon_core.lib import version_up
-        from ayon_core.pipeline.publish import get_errored_plugins_from_context
-
-        errored_plugins = get_errored_plugins_from_context(context)
-        if any(
-            plugin.__name__ == "FusionSubmitDeadline"
-            for plugin in errored_plugins
-        ):
-            raise KnownPublishError(
-                "Skipping incrementing current file because "
-                "submission to render farm failed."
-            )
-
         comp = context.data.get("currentComp")
         assert comp, "Must have comp"
 
         current_filepath = context.data["currentFile"]
         new_filepath = version_up(current_filepath)
 
-        comp.Save(new_filepath)
+        host: FusionHost = registered_host()
+        with host.current_comp(comp):
+            # Fusion can have multiple compositions open at the same time, and
+            # as a publish is running the user may switch to another comp
+            # simultaneously. Hence, we need to ensure the active comp is the
+            # one current publish session is for.
+            if hasattr(host, "save_workfile_with_context"):
+                from ayon_core.host.interfaces import SaveWorkfileOptionalData
+                host.save_workfile_with_context(
+                    filepath=new_filepath,
+                    folder_entity=context.data["folderEntity"],
+                    task_entity=context.data["taskEntity"],
+                    description="Incremented by publishing.",
+                    # Optimize the save by reducing needed queries for context
+                    prepared_data=SaveWorkfileOptionalData(
+                        project_entity=context.data["projectEntity"],
+                        project_settings=context.data["project_settings"],
+                        anatomy=context.data["anatomy"],
+                    )
+                )
+            else:
+                # Backwards compatibility before:
+                # https://github.com/ynput/ayon-core/pull/1275
+                host.save_workfile(new_filepath)


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Requires latest develop `ayon-core` with this PR included: https://github.com/ynput/ayon-core/pull/1275

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
