### PR TITLE
Farm rendering as 'default' option for Render target

### DIFF
--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -258,7 +258,10 @@ class GenericCreateSaver(Creator):
             "frames": "Use existing frames",
         }
         if "farm_rendering" in self.instance_attributes:
-            rendering_targets["farm"] = "Farm rendering"
+            rendering_targets = {
+                **{"farm": "Farm rendering"},
+                **rendering_targets,
+            }
 
         return EnumDef(
             "render_target", items=rendering_targets, label="Render target"


### PR DESCRIPTION
## Changelog Description
Places "Farm rendering" as the top most option when applicable. 
<img width="671" height="193" alt="image" src="https://github.com/user-attachments/assets/5d5f50e5-3f8f-4943-a63d-c1ab7d6f4214" />

## Additional review information
Makes use of dictionary insertion ordering to place farm rendering as the 'default' option when "farm_rendering" found in instance attributes.

## Testing notes:
1. Check "Farm rendering" is added to instance attributes of Create Saver on Fusion addon Studio/Projects Settings
2. Launch Fusion
3. Open AYON Create menu
4. Validate "Farm rendering" is the 'default' and top most item in the Render target dropdown
