### PR TITLE
Chore: Product base types fixes

### DIFF
--- a/client/ayon_fusion/plugins/publish/collect_render.py
+++ b/client/ayon_fusion/plugins/publish/collect_render.py
@@ -47,7 +47,11 @@ class CollectFusionRender(
                 continue
 
             product_type = inst.data["productType"]
-            if product_type not in ["render", "image"]:
+            product_base_type = inst.data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = product_type
+
+            if product_base_type not in ["render", "image"]:
                 continue
 
             # Get resolution from tool if we can
@@ -65,11 +69,18 @@ class CollectFusionRender(
 
             instance_families = inst.data.get("families", [])
             product_name = inst.data["productName"]
+            kwargs = dict(
+                productBaseType=product_base_type,
+                productType=product_type,
+            )
+            if "productBaseType" not in attr.fields_dict(FusionRenderInstance):
+                kwargs["productType"] = kwargs.pop("productBaseType")
+
             instance = FusionRenderInstance(
+                **kwargs,
                 tool=inst.data["transientData"]["tool"],
                 workfileComp=comp,
-                productType=product_type,
-                family=product_type,
+                family=product_base_type,
                 families=instance_families,
                 version=version,
                 time="",


### PR DESCRIPTION
## Changelog Description
Use product base type in the publish logic.

## Additional review information
This PR was opened because of change in `RenderInstance` (affecting `FusionRenderInstance`) where `productBaseType` was added ([PR](https://github.com/ynput/ayon-core/pull/1687)). With that I've added more changes that can be applied now without any harm.

## Testing notes:
1. Render and image logic still works as expected. Instances can be published.
