### PR TITLE
Increment workfile: Use only newer workfile api

### DIFF
--- a/client/ayon_fusion/plugins/publish/increment_current_file.py
+++ b/client/ayon_fusion/plugins/publish/increment_current_file.py
@@ -2,9 +2,16 @@ import os
 
 import pyblish.api
 
-from ayon_core.pipeline import OptionalPyblishPluginMixin, registered_host
 from ayon_core.lib import version_up
 from ayon_core.host import IWorkfileHost
+from ayon_core.host.interfaces import SaveWorkfileOptionalData
+from ayon_core.pipeline.workfile import save_next_version
+from ayon_core.pipeline import (
+    OptionalPyblishPluginMixin,
+    registered_host,
+    PublishError,
+)
+
 from ayon_fusion.api import FusionHost
 
 
@@ -25,7 +32,8 @@ class FusionIncrementCurrentFile(
             return
 
         comp = context.data.get("currentComp")
-        assert comp, "Must have comp"
+        if not comp:
+            raise PublishError("Must have comp")
 
         # Fusion can have multiple compositions open at the same time, and
         # as a publish is running the user may switch to another comp
@@ -38,28 +46,16 @@ class FusionIncrementCurrentFile(
     def increment_workfile(self, context: pyblish.api.Context):
         """Increment the current workfile version using registered host."""
         current_filepath: str = context.data["currentFile"]
-        try:
-            from ayon_core.pipeline.workfile import save_next_version
-            from ayon_core.host.interfaces import SaveWorkfileOptionalData
 
-            current_filename = os.path.basename(current_filepath)
-            save_next_version(
-                description=(
-                    f"Incremented by publishing from {current_filename}"
-                ),
-                # Optimize the save by reducing needed queries for context
-                prepared_data=SaveWorkfileOptionalData(
-                    project_entity=context.data["projectEntity"],
-                    project_settings=context.data["project_settings"],
-                    anatomy=context.data["anatomy"],
-                )
+        current_filename = os.path.basename(current_filepath)
+        save_next_version(
+            description=(
+                f"Incremented by publishing from {current_filename}"
+            ),
+            # Optimize the save by reducing needed queries for context
+            prepared_data=SaveWorkfileOptionalData(
+                project_entity=context.data["projectEntity"],
+                project_settings=context.data["project_settings"],
+                anatomy=context.data["anatomy"],
             )
-        except ImportError:
-            # Backwards compatibility before ayon-core 1.5.0
-            self.log.debug(
-                "Using legacy `version_up`. Update AYON core addon to "
-                "use newer `save_next_version` function."
-            )
-            new_filepath = version_up(current_filepath)
-            host: IWorkfileHost = registered_host()
-            host.save_workfile(new_filepath)
+        )

--- a/client/ayon_fusion/plugins/publish/increment_current_file.py
+++ b/client/ayon_fusion/plugins/publish/increment_current_file.py
@@ -2,8 +2,6 @@ import os
 
 import pyblish.api
 
-from ayon_core.lib import version_up
-from ayon_core.host import IWorkfileHost
 from ayon_core.host.interfaces import SaveWorkfileOptionalData
 from ayon_core.pipeline.workfile import save_next_version
 from ayon_core.pipeline import (


### PR DESCRIPTION
## Changelog Description
Use only new workfile api.

## Additional review information
Remove backwards compatibility for missing workfiles api.

This PR requires [product base types PR](https://github.com/ynput/ayon-fusion/pull/57) which increases ayon-core compatibile version.

## Testing notes:
1. All should be working.
