### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -45,9 +45,6 @@ class GenericCreateSaver(Creator):
         product_type = instance_data.get("productType")
         if not product_type:
             product_type = self.product_base_type
-            items = self.get_product_type_items()
-            if items:
-                product_type = items[0].product_type
 
         instance = CreatedInstance(
             product_base_type=self.product_base_type,

--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -42,8 +42,16 @@ class GenericCreateSaver(Creator):
     def create(self, product_name, instance_data, pre_create_data):
         self.pass_pre_attributes_to_instance(instance_data, pre_create_data)
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
+            items = self.get_product_type_items()
+            if items:
+                product_type = items[0].product_type
+
         instance = CreatedInstance(
-            product_type=self.product_type,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             product_name=product_name,
             data=instance_data,
             creator=self,
@@ -144,6 +152,7 @@ class GenericCreateSaver(Creator):
 
         # Product name and type
         product_type = formatting_data["productType"]
+        product_base_type = formatting_data["productBaseType"]
         f_product_name = formatting_data["productName"]
 
         # Get instance context entities
@@ -185,6 +194,7 @@ class GenericCreateSaver(Creator):
             "product": {
                 "name": f_product_name,
                 "type": product_type,
+                "basetype": product_base_type,
             },
             # Backwards compatibility
             "subset": f_product_name,

--- a/client/ayon_fusion/plugins/create/create_image_saver.py
+++ b/client/ayon_fusion/plugins/create/create_image_saver.py
@@ -18,8 +18,8 @@ class CreateImageSaver(GenericCreateSaver):
     identifier = "io.openpype.creators.fusion.imagesaver"
     label = "Image (saver)"
     name = "image"
-    product_type = "image"
     product_base_type = "image"
+    product_type = product_base_type
     description = "Fusion Saver to generate a single image file"
 
     default_frame = 0

--- a/client/ayon_fusion/plugins/create/create_saver.py
+++ b/client/ayon_fusion/plugins/create/create_saver.py
@@ -19,8 +19,8 @@ class CreateSaver(GenericCreateSaver):
     identifier = "io.openpype.creators.fusion.saver"
     label = "Render (saver)"
     name = "render"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     description = "Fusion Saver to generate image sequence"
 
     default_frame_range_option = "current_context"

--- a/client/ayon_fusion/plugins/create/create_workfile.py
+++ b/client/ayon_fusion/plugins/create/create_workfile.py
@@ -9,8 +9,8 @@ from ayon_core.pipeline import (
 
 class FusionWorkfileCreator(AutoCreator):
     identifier = "workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     label = "Workfile"
     icon = "fa5.file"
 
@@ -21,7 +21,6 @@ class FusionWorkfileCreator(AutoCreator):
     data_key = "openpype_workfile"
 
     def collect_instances(self):
-
         comp = get_current_comp()
         data = comp.GetData(self.data_key)
         if not data:

--- a/client/ayon_fusion/plugins/create/create_workfile.py
+++ b/client/ayon_fusion/plugins/create/create_workfile.py
@@ -31,6 +31,7 @@ class FusionWorkfileCreator(AutoCreator):
         if product_name is None:
             product_name = data["subset"]
         instance = CreatedInstance(
+            product_base_type=self.product_base_type,
             product_type=self.product_type,
             product_name=product_name,
             data=data,
@@ -98,7 +99,11 @@ class FusionWorkfileCreator(AutoCreator):
             ))
 
             new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_base_type=self.product_base_type,
+                product_type=self.product_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             new_instance.transient_data["comp"] = comp
             self._add_instance_to_context(new_instance)

--- a/client/ayon_fusion/plugins/load/actions.py
+++ b/client/ayon_fusion/plugins/load/actions.py
@@ -8,7 +8,7 @@ from ayon_core.pipeline import load
 class FusionSetFrameRangeLoader(load.LoaderPlugin):
     """Set frame range excluding pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "imagesequence",
@@ -17,6 +17,7 @@ class FusionSetFrameRangeLoader(load.LoaderPlugin):
         "pointcache",
         "render",
     }
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"*"}
 
@@ -45,7 +46,7 @@ class FusionSetFrameRangeLoader(load.LoaderPlugin):
 class FusionSetFrameRangeWithHandlesLoader(load.LoaderPlugin):
     """Set frame range including pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "imagesequence",
@@ -54,6 +55,7 @@ class FusionSetFrameRangeWithHandlesLoader(load.LoaderPlugin):
         "pointcache",
         "render",
     }
+    product_types = product_base_types
     representations = {"*"}
 
     label = "Set frame range (with handles)"

--- a/client/ayon_fusion/plugins/load/load_alembic.py
+++ b/client/ayon_fusion/plugins/load/load_alembic.py
@@ -12,7 +12,8 @@ from ayon_fusion.api import (
 class FusionLoadAlembicMesh(load.LoaderPlugin):
     """Load Alembic mesh into Fusion"""
 
-    product_types = {"pointcache", "model"}
+    product_base_types = {"pointcache", "model"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"abc"}
 

--- a/client/ayon_fusion/plugins/load/load_fbx.py
+++ b/client/ayon_fusion/plugins/load/load_fbx.py
@@ -12,7 +12,8 @@ from ayon_fusion.api import (
 class FusionLoadFBXMesh(load.LoaderPlugin):
     """Load FBX mesh into Fusion"""
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {
         "3ds",

--- a/client/ayon_fusion/plugins/load/load_sequence.py
+++ b/client/ayon_fusion/plugins/load/load_sequence.py
@@ -129,7 +129,7 @@ def loader_shift(loader, frame, relative=True):
 class FusionLoadSequence(load.LoaderPlugin):
     """Load image sequence into Fusion"""
 
-    product_types = {
+    product_base_types = {
         "imagesequence",
         "review",
         "render",
@@ -137,6 +137,7 @@ class FusionLoadSequence(load.LoaderPlugin):
         "image",
         "online",
     }
+    product_types = product_base_types
     representations = {"*"}
     extensions = set(
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)

--- a/client/ayon_fusion/plugins/load/load_usd.py
+++ b/client/ayon_fusion/plugins/load/load_usd.py
@@ -13,7 +13,8 @@ class FusionLoadUSD(load.LoaderPlugin):
     Support for USD was added since Fusion 18.5
     """
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"usd", "usda", "usdz"}
 

--- a/client/ayon_fusion/plugins/load/load_workfile.py
+++ b/client/ayon_fusion/plugins/load/load_workfile.py
@@ -14,7 +14,8 @@ from ayon_fusion.api import (
 class FusionLoadWorkfile(load.LoaderPlugin):
     """Load the content of a workfile into Fusion"""
 
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"comp"}
 

--- a/client/ayon_fusion/plugins/publish/collect_render.py
+++ b/client/ayon_fusion/plugins/publish/collect_render.py
@@ -46,11 +46,7 @@ class CollectFusionRender(
             if not inst.data.get("active", True):
                 continue
 
-            product_type = inst.data["productType"]
-            product_base_type = inst.data.get("productBaseType")
-            if not product_base_type:
-                product_base_type = product_type
-
+            product_base_type = inst.data["productBaseType"]
             if product_base_type not in ["render", "image"]:
                 continue
 
@@ -69,15 +65,10 @@ class CollectFusionRender(
 
             instance_families = inst.data.get("families", [])
             product_name = inst.data["productName"]
-            kwargs = dict(
-                productBaseType=product_base_type,
-                productType=product_type,
-            )
-            if "productBaseType" not in attr.fields_dict(FusionRenderInstance):
-                kwargs["productType"] = kwargs.pop("productBaseType")
 
             instance = FusionRenderInstance(
-                **kwargs,
+                productBaseType=product_base_type,
+                productType=inst.data["productType"],
                 tool=inst.data["transientData"]["tool"],
                 workfileComp=comp,
                 family=product_base_type,

--- a/package.py
+++ b/package.py
@@ -7,6 +7,6 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">1.0.3",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {}

--- a/server/settings.py
+++ b/server/settings.py
@@ -65,6 +65,19 @@ def _set_masterprefs_mode_enum():
     ]
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
 class CreateSaverPluginModel(BaseSettingsModel):
     _isGroup = True
     temp_rendering_path_template: str = SettingsField(
@@ -128,12 +141,26 @@ class CreateSaverModel(CreateSaverPluginModel):
         enum_resolver=_frame_range_options_enum,
         title="Default frame range source"
     )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
 
 
 class CreateImageSaverModel(CreateSaverPluginModel):
     default_frame: int = SettingsField(
         0,
         title="Default rendered frame"
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
     )
 
 


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of Fusion is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Render and image create plugins have option to define product type items.

## Testing notes:
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Existing workfiles should load up and should be possible to publish.
3. Creating new instances should work as expected.

### Product types
1. Define product types for a create plugin.
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI.