### PR TITLE
Creators: Configure default render target in settings

### DIFF
--- a/client/ayon_fusion/api/plugin.py
+++ b/client/ayon_fusion/api/plugin.py
@@ -33,6 +33,8 @@ class GenericCreateSaver(Creator):
 
     image_format = "exr"
 
+    default_render_target = "local"
+
     # TODO: This should be renamed together with Nuke so it is aligned
     temp_rendering_path_template = (
         "{workdir}/renders/fusion/{product[name]}/"
@@ -261,21 +263,24 @@ class GenericCreateSaver(Creator):
             rendering_targets["farm"] = "Farm rendering"
 
         return EnumDef(
-            "render_target", items=rendering_targets, label="Render target"
+            "render_target",
+            label="Render target",
+            items=rendering_targets,
+            default=self.default_render_target,
         )
 
     def _get_reviewable_bool(self):
         return BoolDef(
             "review",
-            default=("reviewable" in self.instance_attributes),
             label="Review",
+            default=("reviewable" in self.instance_attributes),
         )
 
     def _get_image_format_enum(self):
         image_format_options = ["exr", "tga", "tif", "png", "jpg", "dpx"]
         return EnumDef(
             "image_format",
+            label="Output Image Format",
             items=image_format_options,
             default=self.image_format,
-            label="Output Image Format",
         )

--- a/server/settings.py
+++ b/server/settings.py
@@ -65,6 +65,14 @@ def _set_masterprefs_mode_enum():
     ]
 
 
+def _render_target_enum():
+    return [
+        {"value": "local", "label": "Local machine rendering"},
+        {"value": "frames", "label": "Use existing frames"},
+        {"value": "farm", "label": "Farm rendering"},
+    ]
+
+
 class CreateSaverPluginModel(BaseSettingsModel):
     _isGroup = True
     temp_rendering_path_template: str = SettingsField(
@@ -82,6 +90,11 @@ class CreateSaverPluginModel(BaseSettingsModel):
     image_format: str = SettingsField(
         enum_resolver=_image_format_enum,
         title="Output Image Format"
+    )
+    default_render_target: str = SettingsField(
+        default="local",
+        enum_resolver=_render_target_enum,
+        title="Default Render Target"
     )
 
 
@@ -224,6 +237,7 @@ DEFAULT_VALUES = {
                 "farm_rendering"
             ],
             "image_format": "exr",
+            "default_render_target": "local",
             "default_frame_range_option": "current_context"
         },
         "CreateImageSaver": {
@@ -237,6 +251,7 @@ DEFAULT_VALUES = {
                 "farm_rendering"
             ],
             "image_format": "exr",
+            "default_render_target": "local",
             "default_frame": 0
         }
     },


### PR DESCRIPTION
## Changelog Description

Make default render target configurable in settings at:
- `ayon+settings://fusion/create/CreateSaver/default_render_target`
- `ayon+settings://fusion/create/CreateImageSaver/default_render_target`

## Additional review information

Replaces PR: https://github.com/ynput/ayon-fusion/pull/52

## Testing notes:

1. Default render target should be configurable in settings.